### PR TITLE
Add advanced agents and expose training diagnostics

### DIFF
--- a/dynamic_rl_stock_trading/agents.py
+++ b/dynamic_rl_stock_trading/agents.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 
@@ -42,6 +42,10 @@ class AgentMetrics:
             return "N/A"
         return ACTIONS[self.actions[-1]]
 
+    @property
+    def steps(self) -> int:
+        return len(self.rewards)
+
 
 class BaseAgent:
     """Interface implemented by trading agents."""
@@ -59,6 +63,16 @@ class BaseAgent:
 
     def update_metrics(self, reward: float, action: int) -> None:
         self.metrics.register(reward=reward, action=action)
+
+    def training_details(self) -> Dict[str, Any]:
+        """Return a dictionary with algorithm specific diagnostics."""
+
+        return {
+            "Strategy": self.name,
+            "States Tracked": 0,
+            "Exploration": "N/A",
+            "Experience Steps": self.metrics.steps,
+        }
 
 
 class QLearningAgent(BaseAgent):
@@ -94,6 +108,16 @@ class QLearningAgent(BaseAgent):
         next_q_values = self._ensure_state(next_state)
         td_target = reward + self.gamma * np.max(next_q_values)
         q_values[action] += self.alpha * (td_target - q_values[action])
+
+    def training_details(self) -> Dict[str, Any]:  # noqa: D401
+        return {
+            "Strategy": self.name,
+            "States Tracked": len(self.q_table),
+            "Exploration": f"ε-greedy (ε={self.epsilon:.2f})",
+            "Learning Rate": self.alpha,
+            "Discount": self.gamma,
+            "Experience Steps": self.metrics.steps,
+        }
 
 
 class SarsaAgent(BaseAgent):
@@ -134,6 +158,16 @@ class SarsaAgent(BaseAgent):
         td_target = reward + self.gamma * expected_q
         current_q_values[action] += self.alpha * (td_target - current_q_values[action])
 
+    def training_details(self) -> Dict[str, Any]:  # noqa: D401
+        return {
+            "Strategy": self.name,
+            "States Tracked": len(self.q_table),
+            "Exploration": f"ε-greedy (ε={self.epsilon:.2f})",
+            "Learning Rate": self.alpha,
+            "Discount": self.gamma,
+            "Experience Steps": self.metrics.steps,
+        }
+
 
 class RandomAgent(BaseAgent):
     """Baseline agent that selects actions uniformly at random."""
@@ -146,3 +180,119 @@ class RandomAgent(BaseAgent):
 
     def learn(self, state: Tuple[int, ...], action: int, reward: float, next_state: Tuple[int, ...]) -> None:  # noqa: D401
         return
+
+    def training_details(self) -> Dict[str, Any]:  # noqa: D401
+        return {
+            "Strategy": self.name,
+            "States Tracked": 0,
+            "Exploration": "Uniform random",
+            "Learning Rate": 0.0,
+            "Discount": 0.0,
+            "Experience Steps": self.metrics.steps,
+        }
+
+
+class DoubleQLearningAgent(BaseAgent):
+    """Double Q-learning agent to reduce overestimation bias."""
+
+    def __init__(
+        self,
+        name: str = "Double Q-Learning",
+        action_space: int = 3,
+        alpha: float = 0.3,
+        gamma: float = 0.95,
+        epsilon: float = 0.1,
+    ) -> None:
+        super().__init__(name=name, action_space=action_space)
+        self.alpha = alpha
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.q_table_a: Dict[Tuple[int, ...], np.ndarray] = {}
+        self.q_table_b: Dict[Tuple[int, ...], np.ndarray] = {}
+
+    def _ensure_state(self, state: Tuple[int, ...]) -> Tuple[np.ndarray, np.ndarray]:
+        if state not in self.q_table_a:
+            self.q_table_a[state] = np.zeros(self.action_space, dtype=float)
+            self.q_table_b[state] = np.zeros(self.action_space, dtype=float)
+        return self.q_table_a[state], self.q_table_b[state]
+
+    def select_action(self, state: Tuple[int, ...]) -> int:
+        qa, qb = self._ensure_state(state)
+        combined = qa + qb
+        if np.random.rand() < self.epsilon:
+            return int(np.random.randint(self.action_space))
+        return int(np.argmax(combined))
+
+    def learn(self, state: Tuple[int, ...], action: int, reward: float, next_state: Tuple[int, ...]) -> None:
+        qa, qb = self._ensure_state(state)
+        next_qa, next_qb = self._ensure_state(next_state)
+
+        if np.random.rand() < 0.5:
+            best_action = int(np.argmax(qa))
+            td_target = reward + self.gamma * next_qb[best_action]
+            qa[action] += self.alpha * (td_target - qa[action])
+        else:
+            best_action = int(np.argmax(qb))
+            td_target = reward + self.gamma * next_qa[best_action]
+            qb[action] += self.alpha * (td_target - qb[action])
+
+    def training_details(self) -> Dict[str, Any]:  # noqa: D401
+        visited_states = set(self.q_table_a) | set(self.q_table_b)
+        return {
+            "Strategy": self.name,
+            "States Tracked": len(visited_states),
+            "Exploration": f"ε-greedy (ε={self.epsilon:.2f})",
+            "Learning Rate": self.alpha,
+            "Discount": self.gamma,
+            "Experience Steps": self.metrics.steps,
+        }
+
+
+class BoltzmannQLearningAgent(BaseAgent):
+    """Q-learning agent with Boltzmann exploration."""
+
+    def __init__(
+        self,
+        name: str = "Boltzmann Q-Learning",
+        action_space: int = 3,
+        alpha: float = 0.25,
+        gamma: float = 0.95,
+        temperature: float = 0.5,
+    ) -> None:
+        super().__init__(name=name, action_space=action_space)
+        self.alpha = alpha
+        self.gamma = gamma
+        self.temperature = temperature
+        self.q_table: Dict[Tuple[int, ...], np.ndarray] = {}
+
+    def _ensure_state(self, state: Tuple[int, ...]) -> np.ndarray:
+        if state not in self.q_table:
+            self.q_table[state] = np.zeros(self.action_space, dtype=float)
+        return self.q_table[state]
+
+    def select_action(self, state: Tuple[int, ...]) -> int:
+        q_values = self._ensure_state(state)
+        if self.temperature <= 0:
+            return int(np.argmax(q_values))
+        scaled = q_values / max(self.temperature, 1e-6)
+        # Shift for numerical stability before computing softmax
+        shifted = scaled - np.max(scaled)
+        probabilities = np.exp(shifted)
+        probabilities /= probabilities.sum()
+        return int(np.random.choice(self.action_space, p=probabilities))
+
+    def learn(self, state: Tuple[int, ...], action: int, reward: float, next_state: Tuple[int, ...]) -> None:
+        q_values = self._ensure_state(state)
+        next_q_values = self._ensure_state(next_state)
+        td_target = reward + self.gamma * np.max(next_q_values)
+        q_values[action] += self.alpha * (td_target - q_values[action])
+
+    def training_details(self) -> Dict[str, Any]:  # noqa: D401
+        return {
+            "Strategy": self.name,
+            "States Tracked": len(self.q_table),
+            "Exploration": f"Boltzmann (τ={self.temperature:.2f})",
+            "Learning Rate": self.alpha,
+            "Discount": self.gamma,
+            "Experience Steps": self.metrics.steps,
+        }


### PR DESCRIPTION
## Summary
- add double Q-learning and Boltzmann Q-learning agents with per-algorithm diagnostics
- enhance the simulation manager to surface richer metrics and training detail frames for the UI
- update the Streamlit dashboard to expose the new agents, show diagnostics, and display more detailed status information

## Testing
- python -m compileall dynamic_rl_stock_trading app.py

------
https://chatgpt.com/codex/tasks/task_e_68d924026a048331ab0f964ac2498b28